### PR TITLE
Redirect to chats page if user is already logged

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,4 +1,12 @@
 class HomeController < ApplicationController
+  before_action :redirect_if_logged_in, only: [:index]
+
   def index
+  end
+
+  private
+
+  def redirect_if_logged_in
+    redirect_to chats_path if current_user
   end
 end


### PR DESCRIPTION
I notice that when a user logs in, its possible to visit the home page, but we are rendering the left nav and we end with a weird align:

![image](https://user-images.githubusercontent.com/12720067/233181724-e104aa90-0867-481a-ac27-ee7f4251c4fe.png)

I added a redirection to the chats page if the user is already logged.