### PR TITLE
Adds better wrapping to cards for small screens

### DIFF
--- a/app/views/bots/_bot.erb
+++ b/app/views/bots/_bot.erb
@@ -1,4 +1,4 @@
-<div class="card flex cursor-pointer border-4 px-4 w-full items-end relative"
+<div class="card flex cursor-pointer border-4 px-4 w-full items-center xl:items-end relative"
      data-id="<%= bot.id %>" data-name="<%= bot.name %>"
      data-placeholder="<%= d("Start a new chat with #{bot.name}") %>"
      data-hello="<%= hello_in_user_language %>"

--- a/app/views/chats/new.html.erb
+++ b/app/views/chats/new.html.erb
@@ -1,7 +1,7 @@
 <div class="hidden sm:flex justify-between items-center gap-4 shadow sticky top-0 z-50 bg-slate-800 p-4">
   <h1 class="text-2xl font-medium">New Chat</h1>
 </div>
-<div class="grid sm:grid-cols-3 gap-4 p-4">
+<div class="grid xl:grid-cols-3 gap-4 p-4">
   <%= render Bot.default %>
   <%= render Bot.others %>
 </div>


### PR DESCRIPTION
### Quick Note 

Adds some breakpoints layout adjustments so the Bot Cards won't shrink its image, and have a better layout overall

### Before 
![Screenshot 2023-04-21 at 3 25 50 p m](https://user-images.githubusercontent.com/52474410/233737172-4e74106e-7bb0-4bab-92f4-e0a412ca102e.png)

### After
<img width="953" alt="Screenshot 2023-04-21 at 3 26 18 p m" src="https://user-images.githubusercontent.com/52474410/233737223-1b84cfa2-506d-4c40-b0e7-7db6f468a81f.png">
