### PR TITLE
Enable caching by default in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -29,22 +29,16 @@ config.session_store :redis_session_store,
   # Enable server timing
   config.server_timing = true
 
-  # Enable/disable caching. By default caching is disabled.
-  # Run rails dev:cache to toggle caching.
-  if Rails.root.join("tmp/caching-dev.txt").exist?
-    config.action_controller.perform_caching = true
-    config.action_controller.enable_fragment_cache_logging = true
+  # Enable caching by default for StimulusReflex
+  config.action_controller.perform_caching = true
+  config.action_controller.enable_fragment_cache_logging = true
 
-    config.cache_store = :redis_cache_store, {
-      url: ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" }
-    }
-    config.public_file_server.headers = {
-      "Cache-Control" => "public, max-age=#{2.days.to_i}"
-    }
-  else
-    config.action_controller.perform_caching = false
-    config.cache_store = :null_store
-  end
+  config.cache_store = :redis_cache_store, {
+    url: ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" }
+  }
+  config.public_file_server.headers = {
+    "Cache-Control" => "public, max-age=#{2.days.to_i}"
+  }
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local


### PR DESCRIPTION
StimulusReflex requires caching to be enabled in development mode and the app won't boot without it. Enable by default.
