### PR TITLE
Splitting rails cache and action cable from the same Redis configuration

### DIFF
--- a/config/cable.yml
+++ b/config/cable.yml
@@ -10,3 +10,5 @@ production:
   adapter: redis
   url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
   channel_prefix: magma_chat_production
+  ssl_params:
+    verify_mode: <%= OpenSSL::SSL::VERIFY_NONE %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -18,7 +18,8 @@ Rails.application.configure do
   config.action_controller.enable_fragment_cache_logging = true
 
   config.cache_store = :redis_cache_store, {
-    url: ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" }
+    url: ENV.fetch("REDIS_CACHE_URL") { "redis://localhost:6379/1" },
+    ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE }
   }
   config.public_file_server.headers = {
     "Cache-Control" => "public, max-age=#{2.days.to_i}"

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,7 @@
+Sidekiq.configure_server do |config|
+  config.redis = { ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE } }
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = { ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE } }
+end


### PR DESCRIPTION
We need to have two redis:
* Cache Storage
* Action Cable

Rails cache store will now use `REDIS_CACHE_URL`